### PR TITLE
set up CI/CD workflow for backend tests

### DIFF
--- a/.github/workflows/backend-Tests.yaml
+++ b/.github/workflows/backend-Tests.yaml
@@ -55,6 +55,6 @@ jobs:
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v3
         with:
-          working-directory: backend
+          directory: backend
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/backend-Tests.yaml
+++ b/.github/workflows/backend-Tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: backend/pyproject.toml
+          python-version-file: backend/pyproject.toml
           architecture: x64
 
       - name: Install dependencies (and project)

--- a/.github/workflows/backend-Tests.yaml
+++ b/.github/workflows/backend-Tests.yaml
@@ -50,11 +50,12 @@ jobs:
         working-directory: backend
         env:
           POSTGRES_URI: postgresql+psycopg://postgres:postgres@localhost:5432/postgres
-        run: inv coverage --args "-vvv"
+        run: pytest --cov=./ --cov-report=xml
 
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v3
         with:
           directory: backend
+          files: ./coverage.xml
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/backend-Tests.yaml
+++ b/.github/workflows/backend-Tests.yaml
@@ -16,14 +16,12 @@ jobs:
       postgresdb:
         image: postgres:16.3-bookworm
         env:
-          POSTGRES_DB: mirrors_qa
-          POSTGRES_PASSWORD: mirrors_qa
-          POSTGRES_USER: mirrors_qa
+          POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
         # Set health checks to wait until postgres has started
         options: >-
-          --health-cmd "pg_isready -q -d dbname=mirrors_qa user=mirrors_qa"
+          --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -46,12 +44,12 @@ jobs:
       - name: Create extensions on the PostgreSQL database
         run: >-
           psql -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'
-          "host=localhost port=5432 dbname=mirrors_qa user=mirrors_qa password=mirrors_qa"
+          "host=localhost port=5432 dbname=postgres user=postgres password=postgres"
 
       - name: Run the tests
         working-directory: backend
         env:
-          POSTGRES_URI: postgresql+psycopg://mirrors_qa:mirrors_qa@localhost:5432/mirrors_qa
+          POSTGRES_URI: postgresql+psycopg://postgres:postgres@localhost:5432/postgres
         run: inv coverage --args "-vvv"
 
       - name: Upload coverage report to codecov

--- a/.github/workflows/backend-Tests.yaml
+++ b/.github/workflows/backend-Tests.yaml
@@ -53,7 +53,7 @@ jobs:
         run: inv coverage --args "-vvv"
 
       - name: Upload coverage report to codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: backend
           fail_ci_if_error: true

--- a/.github/workflows/backend-Tests.yaml
+++ b/.github/workflows/backend-Tests.yaml
@@ -50,12 +50,11 @@ jobs:
         working-directory: backend
         env:
           POSTGRES_URI: postgresql+psycopg://postgres:postgres@localhost:5432/postgres
-        run: pytest --cov=./ --cov-report=xml
+        run: inv coverage --args "-vvv"
 
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v3
         with:
-          directory: backend
-          files: ./coverage.xml
+          working-directory: backend
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/backend-Tests.yaml
+++ b/.github/workflows/backend-Tests.yaml
@@ -1,0 +1,64 @@
+name: Backend Tests
+
+on:
+  pull_request:
+  push:
+    paths:
+      - 'backend/**'
+    branches:
+      - main
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-22.04
+
+    services:
+      postgresdb:
+        image: postgres:16.3-bookworm
+        env:
+          POSTGRES_DB: mirrors_qa
+          POSTGRES_PASSWORD: mirrors_qa
+          POSTGRES_USER: mirrors_qa
+        ports:
+          - 5432:5432
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd "pg_isready -q -d dbname=mirrors_qa user=mirrors_qa"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: backend/pyproject.toml
+          architecture: x64
+
+      - name: Install dependencies (and project)
+        working-directory: backend
+        run: |
+          pip install -U pip
+          pip install -e .[test,scripts]
+
+      - name: Create extensions on the PostgreSQL database
+        run: >-
+          psql -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'
+          "host=localhost port=5432 dbname=mirrors_qa user=mirrors_qa password=mirrors_qa"
+
+      - name: Run the tests
+        working-directory: backend
+        env:
+          POSTGRES_URI: postgresql+psycopg://mirrors_qa:mirrors_qa@localhost:5432/mirrors_qa
+        run: inv coverage --args "-vvv"
+
+      - name: Upload coverage report to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: backend
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/backend-Tests.yaml
+++ b/.github/workflows/backend-Tests.yaml
@@ -27,8 +27,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        ports:
-          - 5432:5432
 
     steps:
       - uses: actions/checkout@v4

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -50,6 +50,7 @@ check = [
 test = [
   "pytest==8.0.0",
   "coverage==7.4.1",
+  "pytest-cov==5.0.0",
 ]
 dev = [
   "pre-commit==3.6.0",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -50,7 +50,6 @@ check = [
 test = [
   "pytest==8.0.0",
   "coverage==7.4.1",
-  "pytest-cov==5.0.0",
 ]
 dev = [
   "pre-commit==3.6.0",

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -24,6 +24,7 @@ def report_cov(ctx: Context, *, html: bool = False):
     """report coverage"""
     ctx.run("coverage combine", warn=True, pty=use_pty)
     ctx.run("coverage report --show-missing", pty=use_pty)
+    ctx.run("coverage xml", pty=use_pty)
     if html:
         ctx.run("coverage html", pty=use_pty)
 

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -24,6 +24,7 @@ def report_cov(ctx: Context, *, html: bool = False):
     """report coverage"""
     ctx.run("coverage combine", warn=True, pty=use_pty)
     ctx.run("coverage report --show-missing", pty=use_pty)
+    ctx.run("coverage xml", pty=use_pty)
     if html:
         ctx.run("coverage html", pty=use_pty)
 


### PR DESCRIPTION
## Rationale

Set up CI/CD workflow to ensure tests pass for the backend service

## Changes

- Create a `.github/workflows/backend-Tests.yaml` file to run tests on pull requests and pushes to `main`
