### PR TITLE
use local images in dev instead of published ones

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -20,7 +20,8 @@ services:
     depends_on:
       postgresdb:
         condition: service_healthy
-    image: kiwix/mirrors-qa-backend
+    build:
+      context: ../backend
     container_name: mirrors-qa-backend
     environment:
       POSTGRES_URI: postgresql+psycopg://mirrors_qa:mirrors_qa@postgresdb:5432/mirrors_qa
@@ -29,7 +30,9 @@ services:
     ports:
       - 8000:80
   worker_manager:
-    image: kiwix/mirrors-qa-worker-manager
+    build:
+      context: ../worker
+      dockerfile: manager.Dockerfile
     container_name: mirrors-qa-worker-manager
     environment:
       - BACKEND_ROOT_API=http://backend

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     depends_on:
       postgresdb:
         condition: service_healthy
-    image: openzim/mirrors-qa-backend
+    image: kiwix/mirrors-qa-backend
     container_name: mirrors-qa-backend
     environment:
       POSTGRES_URI: postgresql+psycopg://mirrors_qa:mirrors_qa@postgresdb:5432/mirrors_qa
@@ -29,7 +29,7 @@ services:
     ports:
       - 8000:80
   worker_manager:
-    image: openzim/mirrors-qa-worker-manager
+    image: kiwix/mirrors-qa-worker-manager
     container_name: mirrors-qa-worker-manager
     environment:
       - BACKEND_ROOT_API=http://backend


### PR DESCRIPTION
## Rationale

use `kiwix` as organization name instead of `openzim` in dev docker-compose

## Changes

- replace `image: openzim/mirrors-qa-backend` with `image: kiwix/mirrors-qa-backend`
- replace `image: openzim/mirrors-qa-worker-manager` with `image: kiwix/mirrors-qa-worker-manager`