### PR TITLE
add subcommand for updating mirror detail

### DIFF
--- a/backend/src/mirrors_qa_backend/cli/mirrors.py
+++ b/backend/src/mirrors_qa_backend/cli/mirrors.py
@@ -1,6 +1,16 @@
 from mirrors_qa_backend import logger
 from mirrors_qa_backend.db import Session
-from mirrors_qa_backend.db.mirrors import create_or_update_mirror_status
+from mirrors_qa_backend.db.mirrors import (
+    create_or_update_mirror_status,
+    get_mirror,
+    update_mirror_countries_from_regions,
+)
+from mirrors_qa_backend.db.mirrors import (
+    update_mirror_country as update_db_mirror_country,
+)
+from mirrors_qa_backend.db.mirrors import (
+    update_mirror_region as update_db_mirror_region,
+)
 from mirrors_qa_backend.extract import get_current_mirrors
 
 
@@ -13,3 +23,26 @@ def update_mirrors() -> None:
         f"Updated mirrors list. Added {results.nb_mirrors_added} mirror(s), "
         f"disabled {results.nb_mirrors_disabled} mirror(s)"
     )
+
+
+def update_mirror_other_countries(mirror_id: str, region_codes: set[str]) -> None:
+    with Session.begin() as session:
+        mirror = update_mirror_countries_from_regions(
+            session, get_mirror(session, mirror_id), region_codes
+        )
+
+        logger.info(
+            f"Set {len(mirror.other_countries)} countries "  # pyright: ignore[reportGeneralTypeIssues,reportArgumentType]
+            f"for mirror {mirror.id}"
+        )
+
+
+def update_mirror_region(mirror_id: str, region_code: str) -> None:
+    """Update the region the mirror server is located."""
+    with Session.begin() as session:
+        update_db_mirror_region(session, get_mirror(session, mirror_id), region_code)
+
+
+def update_mirror_country(mirror_id: str, country_code: str) -> None:
+    with Session.begin() as session:
+        update_db_mirror_country(session, get_mirror(session, mirror_id), country_code)

--- a/backend/tests/cli/test_mirror.py
+++ b/backend/tests/cli/test_mirror.py
@@ -1,10 +1,12 @@
 from sqlalchemy.orm import Session as OrmSession
 
 from mirrors_qa_backend.db import models
-from mirrors_qa_backend.db.mirrors import update_mirror_country
+from mirrors_qa_backend.db.mirrors import (
+    _update_mirror_country_and_region,  # pyright: ignore[reportPrivateUsage]
+)
 
 
-def test_update_mirror_region_and_country(
+def test_update_mirror_country_and_region(
     dbsession: OrmSession, db_mirror: models.Mirror
 ):
 
@@ -16,7 +18,7 @@ def test_update_mirror_region_and_country(
     country.region = region
     dbsession.add(country)
 
-    db_mirror = update_mirror_country(dbsession, country.code, db_mirror)
+    db_mirror = _update_mirror_country_and_region(dbsession, country.code, db_mirror)
     assert db_mirror.country is not None
     assert db_mirror.country == country
     assert db_mirror.region == region

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,7 +16,7 @@ from mirrors_qa_backend import schemas
 from mirrors_qa_backend.cryptography import sign_message
 from mirrors_qa_backend.db import Session
 from mirrors_qa_backend.db.country import create_country
-from mirrors_qa_backend.db.models import Base, Mirror, Test, Worker
+from mirrors_qa_backend.db.models import Base, Country, Mirror, Region, Test, Worker
 from mirrors_qa_backend.db.worker import update_worker_countries
 from mirrors_qa_backend.enums import StatusEnum
 from mirrors_qa_backend.serializer import serialize_mirror
@@ -188,3 +188,39 @@ def new_schema_mirror() -> schemas.Mirror:
         as_only=None,
         other_countries=None,
     )
+
+
+@pytest.fixture
+def africa_region(dbsession: OrmSession) -> Region:
+    """Set up a region in Africa and add some default countries."""
+    region = Region(code="af", name="Africa")
+    countries = [
+        Country(code="ng", name="Nigeria"),
+    ]
+    region.countries = countries
+    dbsession.add(region)
+    return region
+
+
+@pytest.fixture
+def europe_region(dbsession: OrmSession) -> Region:
+    """Set up a region in Europe and add some default countries."""
+    region = Region(code="eu", name="Europe")
+    countries = [
+        Country(code="fr", name="France"),
+    ]
+    region.countries = countries
+    dbsession.add(region)
+    return region
+
+
+@pytest.fixture
+def asia_region(dbsession: OrmSession) -> Region:
+    """Set up a region in Asia and add some default countries."""
+    region = Region(code="as", name="Asia")
+    countries = [
+        Country(code="jp", name="Japan"),
+    ]
+    region.countries = countries
+    dbsession.add(region)
+    return region

--- a/backend/tests/db/test_mirrors.py
+++ b/backend/tests/db/test_mirrors.py
@@ -3,14 +3,21 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session as OrmSession
 
 from mirrors_qa_backend import schemas
-from mirrors_qa_backend.db import count_from_stmt, models
+from mirrors_qa_backend.db import count_from_stmt
 from mirrors_qa_backend.db.exceptions import EmptyMirrorsError
-from mirrors_qa_backend.db.mirrors import create_mirrors, create_or_update_mirror_status
+from mirrors_qa_backend.db.mirrors import (
+    create_mirrors,
+    create_or_update_mirror_status,
+    update_mirror_countries_from_regions,
+    update_mirror_country,
+    update_mirror_region,
+)
+from mirrors_qa_backend.db.models import Country, Mirror, Region
 from mirrors_qa_backend.serializer import serialize_mirror
 
 
 def test_db_empty(dbsession: OrmSession):
-    assert count_from_stmt(dbsession, select(models.Country)) == 0
+    assert count_from_stmt(dbsession, select(Country)) == 0
 
 
 def test_create_no_mirrors(dbsession: OrmSession):
@@ -39,7 +46,7 @@ def test_register_new_mirror(
 
 def test_disable_old_mirror(
     dbsession: OrmSession,
-    db_mirror: models.Mirror,  # noqa: ARG001 [pytest fixture that saves a mirror]
+    db_mirror: Mirror,  # noqa: ARG001 [pytest fixture that saves a mirror]
     new_schema_mirror: schemas.Mirror,
 ):
     result = create_or_update_mirror_status(dbsession, [new_schema_mirror])
@@ -60,7 +67,7 @@ def test_re_enable_existing_mirror(
     dbsession: OrmSession,
 ):
     # Create a mirror in the database with enabled set to False
-    db_mirror = models.Mirror(
+    db_mirror = Mirror(
         id="mirrors.dotsrc.org",
         base_url="https://mirrors.dotsrc.org/kiwix/",
         enabled=False,
@@ -81,3 +88,60 @@ def test_re_enable_existing_mirror(
 
     result = create_or_update_mirror_status(dbsession, [schema_mirror])
     assert result.nb_mirrors_added == 1
+
+
+def test_update_mirror_region(
+    dbsession: OrmSession, db_mirror: Mirror, africa_region: Region
+):
+    update_mirror_region(dbsession, db_mirror, africa_region.code)
+    assert db_mirror.region == africa_region
+
+
+def test_update_mirror_country(dbsession: OrmSession, db_mirror: Mirror):
+    country = Country(code="fr", name="France")
+    dbsession.add(country)
+
+    update_mirror_country(dbsession, db_mirror, country.code)
+    assert db_mirror.country == country
+
+
+def test_update_mirror_countries_from_empty_region(
+    dbsession: OrmSession, db_mirror: Mirror, africa_region: Region
+):
+
+    db_mirror.region = africa_region
+    db_mirror.country = africa_region.countries[0]
+    db_mirror.other_countries = ["us", "fr"]
+    dbsession.add(db_mirror)
+
+    update_mirror_countries_from_regions(dbsession, db_mirror, set())
+    assert db_mirror.other_countries == []
+
+
+def test_update_mirror_countries_from_regions(
+    dbsession: OrmSession,
+    db_mirror: Mirror,
+    africa_region: Region,
+    europe_region: Region,
+    asia_region: Region,
+):
+
+    regions = [asia_region, africa_region, europe_region]
+    expected_country_codes = set()
+    region_codes = set()
+
+    for region in regions:
+        region_codes.add(region.code)
+        for country in region.countries:
+            expected_country_codes.add(country.code)
+
+    if db_mirror.country:
+        expected_country_codes.add(db_mirror.country_code)
+
+    db_mirror = update_mirror_countries_from_regions(dbsession, db_mirror, region_codes)
+
+    assert db_mirror.other_countries is not None
+    assert len(expected_country_codes) == len(db_mirror.other_countries)
+
+    for country_code in expected_country_codes:
+        assert country_code in db_mirror.other_countries

--- a/backend/tests/db/test_mirrors.py
+++ b/backend/tests/db/test_mirrors.py
@@ -127,16 +127,13 @@ def test_update_mirror_countries_from_regions(
 ):
 
     regions = [asia_region, africa_region, europe_region]
-    expected_country_codes = set()
-    region_codes = set()
+    expected_country_codes: set[str] = set()
+    region_codes: set[str] = set()
 
     for region in regions:
         region_codes.add(region.code)
         for country in region.countries:
             expected_country_codes.add(country.code)
-
-    if db_mirror.country:
-        expected_country_codes.add(db_mirror.country_code)
 
     db_mirror = update_mirror_countries_from_regions(dbsession, db_mirror, region_codes)
 


### PR DESCRIPTION
# Changes

- add subcommand for updating a mirror's details
   - update the list of other countries for a mirror using `--regions`. This sets the `other_countries` using all the countries found in the provided regions in addition to the countries in the default region of the mirror.
   - update the default region for a mirror using `--region` 
   - update the default country of a mirror using `--country`
   
 These changes (in additon to #42 ) lay the foundation for #39 as the initial db schema didn't have regions or country information in mirrors