### PR TITLE
remove stdin default from create-countries subcommand

### DIFF
--- a/backend/src/mirrors_qa_backend/entrypoint.py
+++ b/backend/src/mirrors_qa_backend/entrypoint.py
@@ -113,11 +113,9 @@ def main():
         "country_region_csv_file",
         metavar="csv-file",
         type=argparse.FileType("r", encoding="utf-8"),
-        nargs="?",
-        default=sys.stdin,
         help=(
             "CSV file containing countries and associated regions "
-            "(format: Maxmind's GeoIPLite Country Locations csv) (default: stdin)."
+            "(format: Maxmind's GeoIPLite Country Locations csv)."
         ),
     )
 


### PR DESCRIPTION
# Changes
- Remove `stdin` default from `create-countries` subcommand.

This resolves #44 