### PR TITLE
add setting for client to update wireguard port.

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -123,6 +123,7 @@ The `backend` code houses the `scheduler` and the `RESTful API`. The following e
 - `DOCKER_API_RETRIES`: how many times to retry requests to the Docker daemon
 - `DOCKER_API_RETRY_DURATION`: how long to wait before retrying a failed request
 - `WIREGUARD_IMAGE`
+- `WIREGUARD_PORT`: port for routing wireguard traffic in the wireguard container. This is not the exposed port.
 - `WIREGUARD_KERNEL_MODULES`: where to load wireguard kernel modules from (default `/lib/modules`)
 - `WIREGUARD_HEALTHCHECK_INTERVAL_SECONDS`
 - `WIREGUARD_HEALTHCHECK_TIMEOUT_SECONDS`

--- a/worker/manager/src/mirrors_qa_manager/settings.py
+++ b/worker/manager/src/mirrors_qa_manager/settings.py
@@ -40,6 +40,7 @@ class Settings:
     WIREGUARD_CONTAINER_NAME = getenv(
         "WIREGUARD_CONTAINER_NAME", default="mirrors-qa-wireguard"
     )
+    WIREGUARD_PORT = int(getenv("WIREGUARD_PORT", default=51820))
     # Optional path for loading kernel modules for wireguard container
     WIREGUARD_KERNEL_MODULES_FPATH = Path(
         getenv("WIREGUARD_KERNEL_MODULES", default="/lib/modules")


### PR DESCRIPTION
# Changes

- make wireguard port configurable in case client wants to use a different port. Working on the ProtonVPN config downloader, I realized that the hard-coded port of `51820` didn't have to be fixed.
- use better type annotations for generator function - `fetch_tests`
- show error message on Docker `APIError`